### PR TITLE
implementa pytest no Docker com GitHub Actions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -16,3 +16,5 @@ jobs:
       run: make docker-test
     - name: Run flake8
       run: make docker-flake8
+    - name: Run gootables
+      run: make docker-validate

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,0 +1,18 @@
+name: pytest@docker
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the docker development image
+      run: make docker-build-dev
+    - name: Run pytest suite
+      run: make docker-test
+    - name: Run flake8
+      run: make docker-flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
 FROM python:3.8-slim
 
-COPY requirements.txt /tmp/requirements.txt
+WORKDIR /opt/covid19-br
+
+ARG PYTHON_REQUIREMENTS=collect
+
+COPY requirements.txt .
+COPY requirements-${PYTHON_REQUIREMENTS}.txt .
 
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
-        g++ \
+        build-essential \
     && python -m pip install --upgrade pip \
-    && pip install -r /tmp/requirements.txt \
-    && apt-get remove -y g++ \
+    && pip install -r  requirements-${PYTHON_REQUIREMENTS}.txt\
+    && apt-get remove -y build-essential \
     && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/covid19-br
 COPY ./ /opt/covid19-br

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ docker-build:
 docker-collect:
 	docker container run --rm --name covid19-br --volume $(PWD)/data/output:/opt/covid19-br/data/output covid19-br ./collect.sh
 
-docker-run:
+docker-run: docker-build
 	docker container run --rm --name covid19-br --volume $(PWD)/data/output:/opt/covid19-br/data/output covid19-br ./run.sh
 
 docker-build-dev:
@@ -24,3 +24,6 @@ docker-flake8: docker-build-dev
 
 docker-deploy:
 	docker container run --env-file ./.env --rm --name covid19-br --volume $(PWD)/data/output:/opt/covid19-br/data/output covid19-br ./deploy.sh
+
+docker-validate: docker-run
+	docker container run --rm --name covid19-br --volume $(PWD)/data/output:/opt/covid19-br/data/output covid19-br ./validate.sh

--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,15 @@ docker-collect:
 docker-run:
 	docker container run --rm --name covid19-br --volume $(PWD)/data/output:/opt/covid19-br/data/output covid19-br ./run.sh
 
+docker-build-dev:
+	docker image build -t covid19-br-dev --build-arg PYTHON_REQUIREMENTS=development .
+
+docker-test: docker-build-dev
+	docker container run --rm covid19-br-dev pytest tests/
+
+docker-flake8: docker-build-dev
+	docker container run --rm covid19-br-dev flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	docker container run --rm covid19-br-dev flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 docker-deploy:
 	docker container run --env-file ./.env --rm --name covid19-br --volume $(PWD)/data/output:/opt/covid19-br/data/output covid19-br ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # covid19-br
 
+![pytest@docker](https://github.com/turicas/covid19-br/workflows/pytest@docker/badge.svg)
+
 Esse repositório centraliza links e dados sobre boletins de número de casos das
 secretarias de saúde estaduais sobre a pandemia de coronavírus no Brasil. O
 recorte é por município por dia, para acompanharmos localmente a evolução da

--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -4,3 +4,5 @@ autoflake
 black
 ipython
 isort
+pytest
+flake8

--- a/tests/sample_test.py
+++ b/tests/sample_test.py
@@ -1,0 +1,6 @@
+import unittest
+ 
+class TestSample(unittest.TestCase):
+ 
+    def test_true(self):
+        self.assertEqual( 1, 1)


### PR DESCRIPTION
foi adaptado o `Dockerfile` para aceitar build com parêmetros, assim é
possível construir uma imagem para executar os scripts e uma imagem para
rodar rotinas de desenvolvimento

no `Makefile` foram adicionados targets para construir imagem de
desenvolvimento e rodar os testes

foi adicionado um arquivo de workflow para o GitHub Actions utilizando
essa infraestrutura do `Dockerfile` e `Makefile`, assim, os passos para
rodar são iguais tanto no ambiente do desenvolvedor quanto no ambiente
de CI