### PR TITLE
adiciona os novos CVSs para validação no Data Package

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -241,6 +241,182 @@
           }
         ]
       }
+    },
+    {
+      "name": "schema-epidemiological-week",
+      "path": "schema/epidemiological-week.csv",
+      "profile": "tabular-data-resource",
+      "schema": {
+        "fields": [
+          {
+            "name": "field_name",
+            "type": "string",
+            "format": "default",
+            "title": "Nome do campo"
+          },
+          {
+            "name": "field_type",
+            "type": "string",
+            "format": "default",
+            "title": "Tipo de campo"
+          }
+        ]
+      }
+    },
+    {
+      "name": "schema-obito_cartorio",
+      "path": "schema/obito_cartorio.csv",
+      "profile": "tabular-data-resource",
+      "schema": {
+        "fields": [
+          {
+            "name": "field_name",
+            "type": "string",
+            "format": "default",
+            "title": "Nome do campo"
+          },
+          {
+            "name": "field_type",
+            "type": "string",
+            "format": "default",
+            "title": "Tipo de campo"
+          }
+        ]
+      }
+    },
+    {
+      "name": "epidemiological-week",
+      "path": "data/epidemiological-week.csv",
+      "profile": "tabular-data-resource",
+      "schema": {
+        "fields": [
+          {
+            "name": "date",
+            "type": "date",
+            "format": "default",
+            "title": "Data"
+          },
+          {
+            "name": "epidemiological_year",
+            "type": "integer",
+            "format": "default",
+            "title": "Ano epidemiológico"
+          },
+          {
+            "name": "epidemiological_week",
+            "type": "integer",
+            "format": "default",
+            "title": "Semana epidemiológica"
+          }
+        ]
+      }
+    },
+    {
+      "name": "obito_cartorio",
+      "path": "data/output/obito_cartorio.csv",
+      "profile": "tabular-data-resource",
+      "schema": {
+        "fields": [
+          {
+            "name": "date",
+            "type": "date",
+            "format": "default",
+            "title": "Data do óbito",
+            "description": "Data da ocorrência do óbito no formato YYYY-MM-DD"
+          },
+          {
+            "name": "state",
+            "type": "string",
+            "format": "default",
+            "title": "UF",
+            "description": "Sigla da unidade federativa com dois dígitos, exemplo: SP."
+          },
+          {
+            "name": "new_deaths_respiratory_failure_2019",
+            "type": "integer",
+            "format": "default",
+            "title": "Óbitos por pneumonia nesta data em 2019",
+            "description": "Quantidade de óbitos registrados nesse dia e mês (de `date`) em decorrência de pneumonia para o estado em `state`, porém para o ano de 2019."
+          },
+          {
+            "name": "new_deaths_respiratory_failure_2020",
+            "type": "integer",
+            "format": "default",
+            "title": "Óbitos por pneumonia (2020)",
+            "description": "Quantidade de óbitos registrados nesse dia/mês/ano (de `date`) em decorrência de pneumonia para esse o estado em `state`."
+          },
+          {
+            "name": "new_deaths_pneumonia_2019",
+            "type": "integer",
+            "format": "default",
+            "title": "Óbitos por suspeita ou confirmação de covid19",
+            "description": "Quantidade de óbitos em decorrência de **suspeita ou confirmação** de covid19 registrados nesse dia e mês (de `date`) para o estado em `state`, porém para o ano de 2019."
+          },
+          {
+            "name": "new_deaths_pneumonia_2020",
+            "type": "integer",
+            "format": "default",
+            "title": "Óbitos por insuficiência respiratória nesta data em 2019",
+            "description": "Quantidade de óbitos registrados nesse dia e mês (de `date`) em decorrência de insuficiência respiratória para o estado em `state`, porém para o ano de 2019."
+          },
+          {
+            "name": "new_deaths_covid19",
+            "type": "integer",
+            "format": "default",
+            "title": "Óbitos por insuficiência respiratória (2020)",
+            "description": "Quantidade de óbitos registrados nesse dia/mês/ano (de `date`) em decorrência de insuficiência respiratória para esse o estado em `state`."
+          },
+          {
+            "name": "epidemiological_week_2019",
+            "type": "integer",
+            "format": "default",
+            "title": "Semana epidemiológica (2019)",
+            "description": "Número da semana epidemiológica para essa data em 2019."
+          },
+          {
+            "name": "epidemiological_week_2020",
+            "type": "integer",
+            "format": "default",
+            "title": "Semana epidemiológica (2020)",
+            "description": "Número da semana epidemiológica para essa data em 2020."
+          },
+          {
+            "name": "deaths_covid19",
+            "type": "integer",
+            "format": "default",
+            "title": "Novas mortes por pneumonia Novas mortes por pneumonia nesta data (2019)nesta data (2019)",
+            "description": "Novas mortes por pneumonia nesta data (2019)"
+          },
+          {
+            "name": "deaths_respiratory_failure_2019",
+            "type": "integer",
+            "format": "default",
+            "title": "Novas mortes por pneumonia (2020)",
+            "description": "Novas mortes por pneumonia (2020)"
+          },
+          {
+            "name": "deaths_respiratory_failure_2020",
+            "type": "integer",
+            "format": "default",
+            "title": "Novas mortes por covid19",
+            "description": "Novas mortes por covid19"
+          },
+          {
+            "name": "deaths_pneumonia_2019",
+            "type": "integer",
+            "format": "default",
+            "title": "Novas mortes por insuficiência respiratória nesta data (2019)",
+            "description": "Novas mortes por insuficiência respiratória nesta data (2019)"
+          },
+          {
+            "name": "deaths_pneumonia_2020",
+            "type": "integer",
+            "format": "default",
+            "title": "Novas mortes por insuficiência respiratória (2020)",
+            "description": "Novas mortes por insuficiência respiratória (2020)"
+          }
+        ]
+      }
     }
   ],
   "keywords": [


### PR DESCRIPTION
Acrescentei as novas planilhas e esquemas no `datapackage.json`. Agora também serão verificados para validação:

* `data/output/obito_cartorio.csv`
* `data/epidemiological-week.csv`
* `schema/epidemiological-week.csv`
* `schema/obito_cartorio.csv`

Para validar, digite o script `validate.sh`. Segue o resultado da primeira execução:

```
$ ./validate.sh 
DATASET
=======
{'error-count': 1,
 'preset': 'nested',
 'table-count': 10,
 'time': 12.472,
 'valid': False}

TABLE [1]
=========
{'datapackage': 'datapackage.json',
 'error-count': 1,
 'format': 'inline',
 'headers': ['date', 'state', 'url', 'notes'],
 'resource-name': 'boletim',
 'row-count': 1038,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/data/output/boletim.csv',
 'time': 5.32,
 'valid': False}
---------
[897,3] [type-or-format-error] The value "=HYPERLINK("http://www.saude.ba.gov.br/wp-content/uploads/2020/04/boletimEpidemiogicoCovid-19_nº-14-09-04-2020.pdf","http://www.saude.ba.gov.br/wp-content/uploads/2020/04/boletimEpidemiogicoCovid-19_nº-14-09-04-2020.pdf")" in row 897 and column 3 is not type "string" and format "uri"

TABLE [2]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['date',
             'state',
             'city',
             'place_type',
             'confirmed',
             'deaths',
             'order_for_place',
             'is_last',
             'estimated_population_2019',
             'city_ibge_code',
             'confirmed_per_100k_inhabitants',
             'death_rate'],
 'resource-name': 'caso',
 'row-count': 11614,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/data/output/caso.csv',
 'time': 12.124,
 'valid': True}

TABLE [3]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['state',
             'state_ibge_code',
             'city_ibge_code',
             'city',
             'estimated_population'],
 'resource-name': 'populacao-estimada',
 'row-count': 5571,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/data/populacao-estimada-2019.csv',
 'time': 1.748,
 'valid': True}

TABLE [4]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['field_name', 'field_type'],
 'resource-name': 'schema-boletim',
 'row-count': 5,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/schema/boletim.csv',
 'time': 0.282,
 'valid': True}

TABLE [5]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['field_name', 'field_type'],
 'resource-name': 'schema-caso',
 'row-count': 13,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/schema/caso.csv',
 'time': 0.372,
 'valid': True}

TABLE [6]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['field_name', 'field_type'],
 'resource-name': 'schema-populacao-estimada',
 'row-count': 6,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/schema/populacao-estimada-2019.csv',
 'time': 0.176,
 'valid': True}

TABLE [7]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['field_name', 'field_type'],
 'resource-name': 'schema-epidemiological-week',
 'row-count': 4,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/schema/epidemiological-week.csv',
 'time': 0.222,
 'valid': True}

TABLE [8]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['field_name', 'field_type'],
 'resource-name': 'schema-obito_cartorio',
 'row-count': 15,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/schema/obito_cartorio.csv',
 'time': 0.441,
 'valid': True}

TABLE [9]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['date', 'epidemiological_year', 'epidemiological_week'],
 'resource-name': 'epidemiological-week',
 'row-count': 3289,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/data/epidemiological-week.csv',
 'time': 9.142,
 'valid': True}

TABLE [10]
=========
{'datapackage': 'datapackage.json',
 'error-count': 0,
 'format': 'inline',
 'headers': ['date',
             'state',
             'new_deaths_respiratory_failure_2019',
             'new_deaths_respiratory_failure_2020',
             'new_deaths_pneumonia_2019',
             'new_deaths_pneumonia_2020',
             'new_deaths_covid19',
             'epidemiological_week_2019',
             'epidemiological_week_2020',
             'deaths_covid19',
             'deaths_respiratory_failure_2019',
             'deaths_respiratory_failure_2020',
             'deaths_pneumonia_2019',
             'deaths_pneumonia_2020'],
 'resource-name': 'obito_cartorio',
 'row-count': 2782,
 'schema': 'table-schema',
 'source': '/home/user/dev/covid19-br/data/output/obito_cartorio.csv',
 'time': 9.229,
 'valid': True}
```