### PR TITLE
Registral scrapper optimization

### DIFF
--- a/obitos_convert.py
+++ b/obitos_convert.py
@@ -56,7 +56,7 @@ def convert_file(filename):
             row[f"deaths_total_{year}"] = None
 
         for item in data:
-            for year, cause, key in iterate_year_causes_keys("new_deaths", [item.date.year]):
+            for year, cause, key in iterate_year_causes_keys("new_deaths", [str(item.date.year)]):
                 row[key] = getattr(item, cause)
 
         new_deaths_total = Counter()

--- a/obitos_convert.py
+++ b/obitos_convert.py
@@ -8,6 +8,22 @@ from tqdm import tqdm
 
 from date_utils import brazilian_epidemiological_week, one_day
 
+from obitos_spider import DeathsSpider
+DEATH_CAUSES = list(DeathsSpider.causes_map.keys())
+ALL_YEARS = ["2019", "2020"]
+
+def get_death_cause_key(prefix, cause, year):
+    if cause == "covid19":
+        return f"{prefix}_{cause}" if year == "2020" else None
+
+    return f"{prefix}_{cause}_{year}" 
+
+def iterate_year_causes_keys(prefix, years):
+    for year in years:
+        for cause in DEATH_CAUSES:
+            key = get_death_cause_key(prefix, cause, year)
+            if key: 
+                yield (year, cause, key)
 
 def convert_file(filename):
     table = rows.import_from_csv(filename)
@@ -28,69 +44,35 @@ def convert_file(filename):
         )[1]
         row["epidemiological_week_2020"] = brazilian_epidemiological_week(date)[1]
 
-        # There are some missing days on the registral, so default to zero
-        row.update({
-            "new_deaths_sars_2019": 0,
-            "new_deaths_pneumonia_2019": 0,
-            "new_deaths_respiratory_failure_2019": 0,
-            "new_deaths_septicemia_2019": 0,
-            "new_deaths_indeterminate_2019": 0,
-            "new_deaths_others_2019": 0,
-            "new_deaths_sars_2020": 0,
-            "new_deaths_pneumonia_2020": 0,
-            "new_deaths_respiratory_failure_2020": 0,
-            "new_deaths_septicemia_2020": 0,
-            "new_deaths_indeterminate_2020": 0,
-            "new_deaths_others_2020": 0,
-            "new_deaths_covid19": 0
-        })
+        # There are some missing data on the registral, so default all to None
+        # Multiple passes to keep the same column ordering
+        for year, cause, key in iterate_year_causes_keys("new_deaths", ALL_YEARS):
+            row[key] = None
+        for year, cause, key in iterate_year_causes_keys("deaths", ALL_YEARS):
+            row[key] = None
+        for year in ALL_YEARS:
+            row[f"new_deaths_total_{year}"] = None
+        for year in ALL_YEARS:
+            row[f"deaths_total_{year}"] = None
 
         for item in data:
-            year = item.date.year
-            if year == 2020:
-                row["new_deaths_sars_2020"] = item.sars
-                row["new_deaths_pneumonia_2020"] = item.pneumonia
-                row["new_deaths_respiratory_failure_2020"] = item.respiratory_failure
-                row["new_deaths_septicemia_2020"] = item.septicemia
-                row["new_deaths_indeterminate_2020"] = item.indeterminate
-                row["new_deaths_others_2020"] = item.others
-                row["new_deaths_covid19"] = item.covid
-            elif year == 2019:
-                row["new_deaths_sars_2019"] = item.sars
-                row["new_deaths_pneumonia_2019"] = item.pneumonia
-                row["new_deaths_respiratory_failure_2019"] = item.respiratory_failure
-                row["new_deaths_septicemia_2019"] = item.septicemia
-                row["new_deaths_indeterminate_2019"] = item.indeterminate
-                row["new_deaths_others_2019"] = item.others
+            for year, cause, key in iterate_year_causes_keys("new_deaths", [item.date.year]):
+                row[key] = getattr(item, cause)
 
         new_deaths_total = Counter()
-        for year in ("2019", "2020"):
-            for cause in (
-                "sars",
-                "pneumonia",
-                "respiratory_failure",
-                "septicemia",
-                "indeterminate",
-                "others",
-            ):
+        for year, cause, key in iterate_year_causes_keys("new_deaths", ALL_YEARS):
+            new_deaths = row[key]
+            if new_deaths:
                 accumulated_key = f"{state}-{cause}-{year}"
-                new_deaths = row[f"new_deaths_{cause}_{year}"]
                 accumulated[accumulated_key] += new_deaths
-                row[f"deaths_{cause}_{year}"] = accumulated[accumulated_key]
+                row[get_death_cause_key("deaths", cause, year)] = accumulated[accumulated_key]
                 new_deaths_total[f"{year}"] += new_deaths
 
-        accumulated[f"{state}-covid19"] += row["new_deaths_covid19"]
-        row["deaths_covid19"] = accumulated[f"{state}-covid19"]
-        new_deaths_total["2020"] += row["new_deaths_covid19"]
+        for year in ALL_YEARS:
+            accumulated[f"{state}-total-{year}"] += new_deaths_total[year]
+            row[f"new_deaths_total_{year}"] = new_deaths_total[year]
+            row[f"deaths_total_{year}"] = accumulated[f"{state}-total-{year}"]
 
-        row["new_deaths_total_2019"] = new_deaths_total["2019"]
-        row["new_deaths_total_2020"] = new_deaths_total["2020"]
-
-        accumulated[f"{state}-total-2019"] += row["new_deaths_total_2019"]
-        accumulated[f"{state}-total-2020"] += row["new_deaths_total_2020"]
-
-        row["deaths_total_2019"] = accumulated[f"{state}-total-2019"]
-        row["deaths_total_2020"] = accumulated[f"{state}-total-2020"]
         yield row
 
 

--- a/obitos_spider.py
+++ b/obitos_spider.py
@@ -32,6 +32,7 @@ class DeathsSpider(scrapy.Spider):
     )
 
     causes_map = {
+        "covid": "COVID",
         "sars": "SRAG",
         "pneumonia": "PNEUMONIA",
         "respiratory_failure": "INSUFICIENCIA_RESPIRATORIA",
@@ -44,7 +45,7 @@ class DeathsSpider(scrapy.Spider):
         self, start_date, end_date, state, callback, dont_cache=False
     ):
         data = [
-            ("chart", "chart1"),
+            ("chart", "chart5"),
             ("city_id", "all"),
             ("end_date", str(end_date)),
             ("places[]", "HOSPITAL"),
@@ -61,56 +62,26 @@ class DeathsSpider(scrapy.Spider):
         )
 
     def start_requests(self):
-        today = date_utils.today()
-        tomorrow = today + datetime.timedelta(days=1)
-        # `date_utils.date_range` excludes the last, so to get today's data we
-        # need to pass tomorrow.
-        for date in date_utils.date_range(datetime.date(2020, 1, 1), tomorrow):
-            # Won't cache dates from 30 days ago until today (only historical
-            # ones which are unlikely to change).
-            should_cache = today - date > datetime.timedelta(days=30)
-            for state in STATES:
+        for state in STATES:
+            for year in [2020, 2019]:
                 yield self.make_registral_request(
-                    start_date=date,
-                    end_date=date,
+                    start_date=datetime.date(year, 1, 1),
+                    end_date=datetime.date(year, 12, 31),
                     state=state,
                     callback=self.parse_registral_request,
-                    dont_cache=not should_cache,
+                    dont_cache=True,
                 )
 
-    def add_causes(self, row, data, year):
-        for cause, portuguese_name in self.causes_map.items():
-            row[cause + "_" + year] = data[portuguese_name]
-
     def parse_registral_request(self, response):
-        row = response.meta["row"].copy()
+        state = response.meta["row"]["state"]
         data = json.loads(response.body)
-        assert row["start_date"] == row.pop("end_date")
-        row["date"] = row.pop("start_date")
-        year, month, day = row["date"].split("-")
-        date = datetime.date(int(year), int(month), int(day))
-        if "dont_cache" in row:
-            del row["dont_cache"]
 
-        for year in ["2019", "2020"]:
-            for cause in self.causes_map:
-                row[cause + "_" + year] = 0
-
-        row["covid"] = 0
-
-        chart_data = data["chart"]
-        if chart_data:
-            if "2019" in chart_data and "2020" in chart_data:
-                try:
-                    datetime.date(2019, date.month, date.day)
-                except ValueError:
-                    # This day does not exist on 2019 and the API returned
-                    # 2019's next day data.
-                    pass
-                else:
-                    self.add_causes(row, chart_data["2019"], "2019")
-
-                self.add_causes(row, chart_data["2020"], "2020")
-                row["covid"] = chart_data["2020"]["COVID"]
-
-        yield row
+        for br_date, chart in data["chart"].items():
+            day, month, year = br_date.split("/")
+            date = datetime.date(int(year), int(month), int(day))
+            
+            row = {"date": date, "state": state}
+            for cause, portuguese_name in self.causes_map.items():
+                row[cause] = chart[portuguese_name][0]["total"] if portuguese_name in chart else 0
+            
+            yield row

--- a/obitos_spider.py
+++ b/obitos_spider.py
@@ -32,13 +32,13 @@ class DeathsSpider(scrapy.Spider):
     )
 
     causes_map = {
-        "covid": "COVID",
         "sars": "SRAG",
         "pneumonia": "PNEUMONIA",
         "respiratory_failure": "INSUFICIENCIA_RESPIRATORIA",
         "septicemia": "SEPTICEMIA",
         "indeterminate": "INDETERMINADA",
         "others": "OUTRAS",
+        "covid19": "COVID",
     }
 
     def make_registral_request(
@@ -82,6 +82,6 @@ class DeathsSpider(scrapy.Spider):
             
             row = {"date": date, "state": state}
             for cause, portuguese_name in self.causes_map.items():
-                row[cause] = chart[portuguese_name][0]["total"] if portuguese_name in chart else 0
+                row[cause] = chart[portuguese_name][0]["total"] if portuguese_name in chart else None
             
             yield row


### PR DESCRIPTION
Use the newer full year query instead of doing day-by-day, runs in seconds now, so I've also disabled the caching.

I've checked the data and it's ok.

Also I changed the sort to be "state, date" instead of "date, state", not sure if it breaks something.

Finally I'm including the whole year in the query as the 2019 data may be useful.