### PR TITLE
adiciona spider para PB

### DIFF
--- a/corona_pb_spider.py
+++ b/corona_pb_spider.py
@@ -20,10 +20,12 @@ class PBSpider(scrapy.Spider):
             if url.startswith('https://paraiba.pb.gov.br/diretas/saude/coronavirus/noticias/atualizacao-covid-19'):
                 yield response.follow(url, self.parse)
 
+        paragraphs = response.css('p')
+
         yield {
-            "date": self.__get_date(response),
-            "deaths": self.__get_total_deaths(response),
-            "confirmed": self.__get_total_cases(response)
+            "date": self.__get_date(paragraphs),
+            "deaths": self.__get_total_deaths(paragraphs),
+            "confirmed": self.__get_total_cases(paragraphs)
         }
 
     def __get_date(self, response):
@@ -32,23 +34,23 @@ class PBSpider(scrapy.Spider):
 
         return f'{day_and_month}2020'
 
-    def __get_total_cases(self, response):
-        cell_text, *_ = self.__get_confirmed_paragraph(response)
+    def __get_total_cases(self, paragraphs):
+        cell_text, *_ = self.__get_confirmed_paragraph(paragraphs)
 
         return self.__extract_number(cell_text)
 
-    def __get_confirmed_paragraph(self, response):
-        return [p.get() for p in response.css('p') if 'Casos Confirmados' in p.get()] or \
-               [p.get() for p in response.css('p') if 'TOTAL CONFIRMADOS' in p.get()]
+    def __get_confirmed_paragraph(self, paragraphs):
+        return [p.get() for p in paragraphs if 'Casos Confirmados' in p.get()] or \
+               [p.get() for p in paragraphs if 'TOTAL CONFIRMADOS' in p.get()]
 
-    def __get_total_deaths(self, response):
-        cell_text, *_ = self.__get_deaths_paragraph(response)
+    def __get_total_deaths(self, paragraphs):
+        cell_text, *_ = self.__get_deaths_paragraph(paragraphs)
 
         return self.__extract_number(cell_text)
 
-    def __get_deaths_paragraph(self, response):
-        return [p.get() for p in response.css('p') if 'Óbitos confirmados' in p.get()] or \
-               [p.get() for p in response.css('p') if 'TOTAL DE ÓBITOS' in p.get()]
+    def __get_deaths_paragraph(self, paragraphs):
+        return [p.get() for p in paragraphs if 'Óbitos confirmados' in p.get()] or \
+               [p.get() for p in paragraphs if 'TOTAL DE ÓBITOS' in p.get()]
 
     def __extract_number(self, text_cell):
         raw_number = re.search('[0-9]+\.?[0-9]+', text_cell).group(0)

--- a/corona_pb_spider.py
+++ b/corona_pb_spider.py
@@ -5,6 +5,7 @@ import scrapy
 
 class PBSpider(scrapy.Spider):
     name = "PB"
+    state = "PB"
 
     def start_requests(self):
         urls = [
@@ -23,9 +24,12 @@ class PBSpider(scrapy.Spider):
         paragraphs = response.css('p')
 
         yield {
-            "date": self.__get_date(paragraphs),
+            "date": self.__get_date(response),
+            "state": self.state,
+            "city": None,
+            "place_type": "state",
+            "confirmed": self.__get_total_cases(paragraphs),
             "deaths": self.__get_total_deaths(paragraphs),
-            "confirmed": self.__get_total_cases(paragraphs)
         }
 
     def __get_date(self, response):

--- a/corona_pb_spider.py
+++ b/corona_pb_spider.py
@@ -33,14 +33,22 @@ class PBSpider(scrapy.Spider):
         return f'{day_and_month}2020'
 
     def __get_total_cases(self, response):
-        cell_text, *_ = [p.get() for p in response.css('.p1') if 'Casos Confirmados' in p.get()]
+        cell_text, *_ = self.__get_confirmed_paragraph(response)
 
         return self.__extract_number(cell_text)
+
+    def __get_confirmed_paragraph(self, response):
+        return [p.get() for p in response.css('p') if 'Casos Confirmados' in p.get()] or \
+               [p.get() for p in response.css('p') if 'TOTAL CONFIRMADOS' in p.get()]
 
     def __get_total_deaths(self, response):
-        cell_text, *_ = [p.get() for p in response.css('.p1') if 'Óbitos confirmados' in p.get()]
+        cell_text, *_ = self.__get_deaths_paragraph(response)
 
         return self.__extract_number(cell_text)
+
+    def __get_deaths_paragraph(self, response):
+        return [p.get() for p in response.css('p') if 'Óbitos confirmados' in p.get()] or \
+               [p.get() for p in response.css('p') if 'TOTAL DE ÓBITOS' in p.get()]
 
     def __extract_number(self, text_cell):
         raw_number = re.search('[0-9]+\.?[0-9]+', text_cell).group(0)

--- a/corona_pb_spider.py
+++ b/corona_pb_spider.py
@@ -1,0 +1,47 @@
+import re
+
+import scrapy
+
+
+class PBSpider(scrapy.Spider):
+    name = "PB"
+
+    def start_requests(self):
+        urls = [
+            'https://paraiba.pb.gov.br/diretas/saude/coronavirus/noticias',
+        ]
+        for url in urls:
+            yield scrapy.Request(url=url, callback=self.parse)
+
+    def parse(self, response):
+        for raw_url in response.css('.url'):
+            url = raw_url.attrib['href']
+
+            if url.startswith('https://paraiba.pb.gov.br/diretas/saude/coronavirus/noticias/atualizacao-covid-19'):
+                yield response.follow(url, self.parse)
+
+        yield {
+            "date": self.__get_date(response),
+            "deaths": self.__get_total_deaths(response),
+            "confirmed": self.__get_total_cases(response)
+        }
+
+    def __get_date(self, response):
+        cell_text = response.css('.documentFirstHeading').get()
+        day_and_month = re.search('[0-9]+\/[0-9]+\/', cell_text).group(0)
+
+        return f'{day_and_month}2020'
+
+    def __get_total_cases(self, response):
+        cell_text, *_ = [p.get() for p in response.css('.p1') if 'Casos Confirmados' in p.get()]
+
+        return self.__extract_number(cell_text)
+
+    def __get_total_deaths(self, response):
+        cell_text, *_ = [p.get() for p in response.css('.p1') if 'Óbitos confirmados' in p.get()]
+
+        return self.__extract_number(cell_text)
+
+    def __extract_number(self, text_cell):
+        raw_number = re.search('[0-9]+\.?[0-9]+', text_cell).group(0)
+        return int(raw_number.replace('.', ''))


### PR DESCRIPTION
Ainda tem uma melhorias necessárias. Por exemplo: atualmente o spider só pega a página inicial da lista de boletins, falta coletar os dados por cidade e não tenho certeza que ele vai estar compatível com o formato de boletins mais antigos. Já tou trabalhando em algumas dessas coisas, mas acho que já quebra o galho na hora de agilizar a geração automática do boletim unificado que a gente quer soltar.

Feeback é muito bem-vindo.