### PR TITLE
Força script de consolidação de dados a usar nomes de 2020 

### DIFF
--- a/consolida.py
+++ b/consolida.py
@@ -63,6 +63,9 @@ class ConsolidaSpider(scrapy.Spider):
         for caso in data:
             for key, value in caso.items():
                 if key == "municipio":
+                    city_info = demographics.get_city(state, value)
+                    if city_info:
+                        caso["municipio"] = city_info.city
                     continue
                 elif key.startswith("confirmados_") or key.startswith("mortes_"):
                     try:


### PR DESCRIPTION
@turicas por alguma razão o endpoint do Brasil.io usado pelo `consolida.py` ainda está retornando os dados usando os nomes de cidade de 2020. O caso de Erer**ê**/**é** para o Ceará dá um pouco da noção do problema (ele é o item 56 da [listagem de casos](https://brasil.io/covid19/import-data/CE/).

Por conta disso, a checagem de chaves que o script `full.py` usa ([triplos de tipo do lugar, estado, cidade](https://github.com/turicas/covid19-br/blob/master/demographics.py#L80)) falhava para as cidades atualizadas e os dados não apareciam no arquivo final `caso_full.csv.gz`.

Esse PR é um fix temporário para a importação de hoje enquanto eu ainda não acertei a rota de import-data.