### PR TITLE
Feature/migrate usernames

### DIFF
--- a/bot/rocketchat.py
+++ b/bot/rocketchat.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 from urllib.parse import urljoin
 
 import requests
@@ -20,6 +21,7 @@ class RocketChat:
         kwargs["headers"] = kwargs.get("headers", {})
         kwargs["headers"]["X-Auth-Token"] = self.auth_token
         kwargs["headers"]["X-User-Id"] = self.user_id
+        kwargs["headers"]["Content-type"] = kwargs.pop("content_type", "")
         return getattr(requests, method)(*args, **kwargs)
 
     def login(self, username, password):
@@ -68,6 +70,16 @@ class RocketChat:
                 yield user
             offset = data["offset"] + data["count"]
             finished = offset == data["total"]
+
+    def user_update(self, user_id: str, data: dict):
+        payload = json.dumps({"userId": user_id, "data": data})
+        response = self.make_request(
+            "POST",
+            self.make_url("users.update"),
+            data=payload,
+            content_type="application/json",
+        )
+        return response.json()
 
 
 if __name__ == "__main__":

--- a/bot/rocketchat.py
+++ b/bot/rocketchat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import json
 from urllib.parse import urljoin
 
 import requests
@@ -21,7 +20,6 @@ class RocketChat:
         kwargs["headers"] = kwargs.get("headers", {})
         kwargs["headers"]["X-Auth-Token"] = self.auth_token
         kwargs["headers"]["X-User-Id"] = self.user_id
-        kwargs["headers"]["Content-type"] = kwargs.pop("content_type", "")
         return getattr(requests, method)(*args, **kwargs)
 
     def login(self, username, password):
@@ -72,12 +70,10 @@ class RocketChat:
             finished = offset == data["total"]
 
     def user_update(self, user_id: str, data: dict):
-        payload = json.dumps({"userId": user_id, "data": data})
         response = self.make_request(
             "POST",
             self.make_url("users.update"),
-            data=payload,
-            content_type="application/json",
+            json={"userId": user_id, "data": data},
         )
         return response.json()
 

--- a/scripts/migrate_rocketchat_usernames.py
+++ b/scripts/migrate_rocketchat_usernames.py
@@ -72,6 +72,9 @@ def migrate(output_filename, commit):
                         )
                     writer.writerow(create_row(invalid_user, suggestion))
                     break
+        else:
+                import sys
+                print(f"Cannot change user (suggestions already used): {invalid_user}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_rocketchat_usernames.py
+++ b/scripts/migrate_rocketchat_usernames.py
@@ -1,7 +1,9 @@
 import argparse
+import csv
 import os
 import re
 
+import rows
 from tqdm import tqdm
 
 from bot.rocketchat import RocketChat
@@ -15,13 +17,33 @@ def is_valid_username(username):
     return not (PUNCT_REGEXP.sub("", username).isdigit() or USERNAME_REGEXP.search(username))
 
 
-def migrate(output_filename):
+def usernames_suggestions(email, name):
+    suggestions = []
+    if email:
+        suggestions.append(rows.utils.slug(email.split("@")[0]))
+    if name:
+        suggestions.append(rows.utils.slug(name))
+
+    return suggestions + [f"{s}_{n}" for s in suggestions for n in range(1, 3)]
+
+
+def create_row(user_data, suggestion):
+    return {
+        "user_id": user_data["user_id"],
+        "old_username": user_data["username"],
+        "new_username": suggestion,
+        "email": user_data["email"]
+    }
+
+
+def migrate(output_filename, commit):
     rocket_chat = RocketChat(os.environ["ROCKETCHAT_BASE_URL"])
     rocket_chat.login(
         os.environ["ROCKETCHAT_USERNAME"],
         os.environ["ROCKETCHAT_PASSWORD"]
     )
     all_users = rocket_chat.user_list()
+
     existing_usernames = set()
     users_data = []
     for user in tqdm(all_users, desc="Baixando informações dos usuários..."):
@@ -35,13 +57,35 @@ def migrate(output_filename):
         users_data.append(data)
         existing_usernames.add(data["username"])
 
-    invalid_users = [u for u in users_data if not u["is_valid"]]
-    for invalid_user in invalid_users:
-        pass
+    with open(output_filename, "w") as csvfile:
+        writer = csv.DictWriter(
+            csvfile,
+            fieldnames=["user_id", "old_username", "new_username", "email"]
+        )
+        writer.writeheader()
+
+        invalid_users = [u for u in users_data if not u["is_valid"]]
+        for invalid_user in tqdm(invalid_users, desc="Atulizando usernames inválidos"):
+            suggestions = usernames_suggestions(invalid_user["email"], invalid_user["name"])
+            for suggestion in suggestions:
+                if suggestion not in existing_usernames:
+                    existing_usernames.add(suggestion)
+                    if commit:
+                        rocket_chat.user_update(
+                            invalid_user["user_id"], {"username": suggestion}
+                        )
+                    writer.writerow(create_row(invalid_user, suggestion))
+                    break
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("output_filename")
+    parser.add_argument(
+        "--commit",
+        default=False,
+        action="store_true",
+        help="Se esta flag for passada o script irá atualizar os dados na API"
+    )
     args = parser.parse_args()
-    data = migrate(args.ouput_filename)
+    data = migrate(args.output_filename, args.commit)

--- a/scripts/migrate_rocketchat_usernames.py
+++ b/scripts/migrate_rocketchat_usernames.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+import re
+
+from tqdm import tqdm
+
+from bot.rocketchat import RocketChat
+
+
+USERNAME_REGEXP = re.compile(r"[^A-Za-z0-9_]")
+PUNCT_REGEXP = re.compile("[-/ .]")
+
+
+def is_valid_username(username):
+    return not (PUNCT_REGEXP.sub("", username).isdigit() or USERNAME_REGEXP.search(username))
+
+
+def migrate(output_filename):
+    rocket_chat = RocketChat(os.environ["ROCKETCHAT_BASE_URL"])
+    rocket_chat.login(
+        os.environ["ROCKETCHAT_USERNAME"],
+        os.environ["ROCKETCHAT_PASSWORD"]
+    )
+    all_users = rocket_chat.user_list()
+    existing_usernames = set()
+    users_data = []
+    for user in tqdm(all_users, desc="Baixando informações dos usuários..."):
+        data = {
+                "user_id": user["_id"],
+                "username": user.get("username"),
+                "name": user.get("name"),
+        }
+        data["email"] = user.get("emails", [{"address": None}])[0]["address"]
+        data["is_valid"] = is_valid_username(data["username"] or ".")
+        users_data.append(data)
+        existing_usernames.add(data["username"])
+
+    invalid_users = [u for u in users_data if not u["is_valid"]]
+    for invalid_user in invalid_users:
+        pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_filename")
+    args = parser.parse_args()
+    data = migrate(args.ouput_filename)

--- a/scripts/migrate_rocketchat_usernames.py
+++ b/scripts/migrate_rocketchat_usernames.py
@@ -58,11 +58,7 @@ def migrate(output_filename, commit):
         existing_usernames.add(data["username"])
 
     with open(output_filename, "w") as csvfile:
-        writer = csv.DictWriter(
-            csvfile,
-            fieldnames=["user_id", "old_username", "new_username", "email"]
-        )
-        writer.writeheader()
+        writer = rows.utils.CsvLazyDictWriter(csvfile)
 
         invalid_users = [u for u in users_data if not u["is_valid"]]
         for invalid_user in tqdm(invalid_users, desc="Atulizando usernames inválidos"):


### PR DESCRIPTION
Cria script para migração dos usernames do RocketChat.

Por default o script roda em modo `dry-run` e irá apenas gerar o CSV com destino `output_file` com as alterações esperadas.
Para atualizar os dados via API é preciso passar a flag `--commit`

### Dry run
```
./migrate_rocketchat_usernames.py output.csv 
```

### For real
```
./migrate_rocketchat_usernames.py output.csv --commit
```